### PR TITLE
Make it possible to configure SAUCE_API_HOST from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Helps connect the local machine to SauceLabs and start a remote browser.
 
-##Install
+## Install
 
 `$ npm install saucelabs-connector`
 
-##Usage
+## Usage
 ```js
 
 var SauceLabsConnector = require('saucelabs-connector');
@@ -57,3 +57,14 @@ saucelabsConnector
     .then(function () {
         return saucelabsConnector.disconnect();
     });
+```
+
+## Additional Configuration
+
+You can select the data center you want to connect to, by setting the environment variable `SAUCE_API_HOST` 
+to the respective data center's host: 
+
+```bash
+export SAUCE_API_HOST=saucelabs.com # for us-west-1, default
+export SAUCE_API_HOST=eu-central-1.saucelabs.com # for eu-central-1
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saucelabs-connector",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "main": "lib/index",
   "description": "Helps connect the local machine to SauceLabs and start a remote browser.",
   "author": "Alexander Moskovkin",
@@ -20,7 +20,7 @@
     "pinkie": "^2.0.4",
     "read-file-relative": "^1.2.0",
     "request": "^2.67.0",
-    "sauce-connect-launcher": "^1.2.1",
+    "sauce-connect-launcher": "^1.2.5",
     "wd": "^1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import wait from './utils/wait';
 import { toAbsPath } from 'read-file-relative';
 import sauceConnectLauncher from 'sauce-connect-launcher';
 import SauceStorage from './sauce-storage';
+import { SAUCE_API_HOST } from './sauce-host';
 
 
 const PRERUN_SCRIPT_DIR_PATH                        = toAbsPath('./prerun/');
@@ -22,7 +23,6 @@ const WEB_DRIVER_CONFIGURATION_TIMEOUT     = 9 * 60 * 1000;
 // So we need to route traffic directly to Google servers to avoid re-signing it with Saucelabs SSL certificates.
 // https://support.saucelabs.com/customer/portal/articles/2005359-some-https-sites-don-t-work-correctly-under-sauce-connect
 const DEFAULT_DIRECT_DOMAINS = ['*.google.com', '*.gstatic.com', '*.googleapis.com'];
-
 
 const requestPromised = promisify(request, Promise);
 
@@ -90,7 +90,7 @@ export default class SaucelabsConnector {
     async _getFreeMachineCount () {
         var params = {
             method: 'GET',
-            url:    ['https://saucelabs.com/rest/v1/users', this.username, 'concurrency'].join('/'),
+            url:    [`https://${SAUCE_API_HOST}/rest/v1/users`, this.username, 'concurrency'].join('/'),
             auth:   { user: this.username, pass: this.accessKey }
         };
 
@@ -102,11 +102,11 @@ export default class SaucelabsConnector {
     async getSessionUrl (browser) {
         var sessionId = await browser.getSessionId();
 
-        return `https://app.saucelabs.com/tests/${sessionId}`;
+        return `https://app.${SAUCE_API_HOST}/tests/${sessionId}`;
     }
 
     async startBrowser (browser, url, { jobName, tags, build } = {}, timeout = null) {
-        var webDriver = wd.promiseChainRemote('ondemand.saucelabs.com', 80, this.username, this.accessKey);
+        var webDriver = wd.promiseChainRemote(`ondemand.${SAUCE_API_HOST}`, 80, this.username, this.accessKey);
 
         var pingWebDriver = () => webDriver.eval('');
 

--- a/src/sauce-host.js
+++ b/src/sauce-host.js
@@ -1,0 +1,3 @@
+// Set the api host from the environment, so it is possible to use e.g. the EU datacenter.
+// https://wiki.saucelabs.com/display/DOCS/Sauce+Labs+European+Data+Center+Configuration+Information
+export const SAUCE_API_HOST = process.env['SAUCE_API_HOST'] || 'saucelabs.com';

--- a/src/sauce-storage.js
+++ b/src/sauce-storage.js
@@ -2,6 +2,7 @@ import Promise from 'pinkie';
 import request from 'request';
 import promisify from 'pify';
 import fs from 'fs';
+import { SAUCE_API_HOST } from './sauce-host';
 
 
 var requestPromised = promisify(request, Promise);
@@ -37,7 +38,7 @@ export default class SauceStorage {
     async isFileAvailable (fileName) {
         var params = {
             method:  'GET',
-            uri:     `https://saucelabs.com/rest/v1/storage/${this.user}`,
+            uri:     `https://${SAUCE_API_HOST}/rest/v1/storage/${this.user}`,
             headers: { 'Content-Type': 'application/json' },
             auth:    { user: this.user, pass: this.pass }
         };
@@ -55,7 +56,7 @@ export default class SauceStorage {
 
         var params = {
             method:  'POST',
-            uri:     `https://saucelabs.com/rest/v1/storage/${this.user}/${fileName}?overwrite=true`,
+            uri:     `https://${SAUCE_API_HOST}/rest/v1/storage/${this.user}/${fileName}?overwrite=true`,
             headers: { 'Content-Type': 'application/octet-stream' },
             auth:    { user: this.user, pass: this.pass },
             body:    buffer.toString('binary', 0, buffer.length)


### PR DESCRIPTION
* add environment variable which sets the SAUCE_API_HOST. This is
  required to use the new EU datacenter.
* use this variable in all the places

Cf. https://github.com/bermi/sauce-connect-launcher/pull/140 for a similar change in sauce-connect-launcher. 

- [x] We will have to update the sauce-connect-launcher dependency, once this is merged. 