### PR TITLE
allow option to use existing sauce connect tunnel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,10 @@ const DEFAULT_DIRECT_DOMAINS = ['*.google.com', '*.gstatic.com', '*.googleapis.c
 const requestPromised = promisify(request, Promise);
 
 function createSauceConnectProcess (options) {
-    if (options.useExistingTunnel){
-        return;
-    }
     return new Promise((resolve, reject) => {
+        if (options.useExistingTunnel){
+            resolve();
+        }
         sauceConnectLauncher(options, (err, process) => {
             if (err) {
                 reject(err);

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,9 @@ const DEFAULT_DIRECT_DOMAINS = ['*.google.com', '*.gstatic.com', '*.googleapis.c
 const requestPromised = promisify(request, Promise);
 
 function createSauceConnectProcess (options) {
+    if (options.useExistingTunnel){
+        return;
+    }
     return new Promise((resolve, reject) => {
         sauceConnectLauncher(options, (err, process) => {
             if (err) {
@@ -46,10 +49,11 @@ function disposeSauceConnectProcess (process) {
 }
 
 export default class SaucelabsConnector {
-    constructor (username, accessKey, options = {}) {
+    constructor (username, accessKey, tunnelIdentifier, options = {}) {
         this.username         = username;
         this.accessKey        = accessKey;
-        this.tunnelIdentifier = Date.now();
+        this.useExistingTunnel = (!tunnelIdentifier);
+        this.tunnelIdentifier = tunnelIdentifier || Date.now();
 
         var {
             connectorLogging = true,
@@ -62,6 +66,7 @@ export default class SaucelabsConnector {
             username:         this.username,
             accessKey:        this.accessKey,
             tunnelIdentifier: this.tunnelIdentifier,
+            useExistingTunnel: this.useExistingTunnel,
             directDomains:    directDomains.join(','),
             logfile:          tunnelLogging ? 'sc_' + this.tunnelIdentifier + '.log' : null
         };

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ function createSauceConnectProcess (options) {
     return new Promise((resolve, reject) => {
         if (options.useExistingTunnel){
             resolve();
+            return;
         }
         sauceConnectLauncher(options, (err, process) => {
             if (err) {


### PR DESCRIPTION
Based on some user requirements, it would be helpful to allow users of this package to specify an existing Sauce Connect tunnel for connecting to instead of starting a new tunnel every time. I tried to add this functionality gracefully.