### PR TITLE
allow extendedDebugging so we can see output on the JavaScript-Console

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saucelabs-connector",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib/index",
   "description": "Helps connect the local machine to SauceLabs and start a remote browser.",
   "author": "Alexander Moskovkin",

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ export default class SaucelabsConnector {
         return `https://app.${SAUCE_API_HOST}/tests/${sessionId}`;
     }
 
-    async startBrowser (browser, url, { jobName, tags, build } = {}, timeout = null) {
+    async startBrowser (browser, url, { jobName, tags, build, extendedDebugging } = {}, timeout = null) {
         var webDriver = wd.promiseChainRemote(`ondemand.${SAUCE_API_HOST}`, 80, this.username, this.accessKey);
 
         var pingWebDriver = () => webDriver.eval('');
@@ -123,11 +123,12 @@ export default class SaucelabsConnector {
         });
 
         var initParams = {
-            name:             jobName,
-            tags:             tags,
-            build:            build,
-            tunnelIdentifier: this.tunnelIdentifier,
-            idleTimeout:      WEB_DRIVER_IDLE_TIMEOUT
+            name:              jobName,
+            tags:              tags,
+            build:             build,
+            extendedDebugging: extendedDebugging,
+            tunnelIdentifier:  this.tunnelIdentifier,
+            idleTimeout:       WEB_DRIVER_IDLE_TIMEOUT            
         };
 
         assign(initParams, browser);

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default class SaucelabsConnector {
             build:             build,
             extendedDebugging: extendedDebugging,
             tunnelIdentifier:  this.tunnelIdentifier,
-            idleTimeout:       WEB_DRIVER_IDLE_TIMEOUT            
+            idleTimeout:       WEB_DRIVER_IDLE_TIMEOUT
         };
 
         assign(initParams, browser);


### PR DESCRIPTION
Hey guys,

it would be great if you could allow us to enable the extendedDebugging-parameter
so we can see output from the JavaScriptConsole and the HTTP-Requests on the SauceLabs-Network-Tab.

thanks a lot,
Alex

PS. We are using this with the package: testcafe-browser-provider-saucelabs 
and an evironment-variable:  SAUCE_CONFIG_PATH that points to a json-file that looks like this:
`
{
    "extendedDebugging": true
}
`