### PR TITLE
Update Saucelabs REST API to version 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saucelabs-connector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/index",
   "description": "Helps connect the local machine to SauceLabs and start a remote browser.",
   "author": {

--- a/src/index.js
+++ b/src/index.js
@@ -120,8 +120,8 @@ export default class SaucelabsConnector {
                  */
 
                 const concurrency = JSON.parse(response.body).concurrency;
-                const orgFreeWindowsMachineCount = concurrency.organization.allowed.vms - concurrency.organization.current.vms
-                const orgFreeMacMachineCount = concurrency.organization.allowed.mac_vms - concurrency.organization.current.mac_vms
+                const orgFreeWindowsMachineCount = concurrency.organization.allowed.vms - concurrency.organization.current.vms;
+                const orgFreeMacMachineCount = concurrency.organization.allowed.mac_vms - concurrency.organization.current.mac_vms;
                 const orgFreeMachineCount = Math.min(orgFreeWindowsMachineCount, orgFreeMacMachineCount);
                 const teamFreeWindowsMachineCount = concurrency.team.allowed.vms - concurrency.team.current.vms;
                 const teamFreeMacMachineCount = concurrency.team.allowed.mac_vms - concurrency.team.current.mac_vms;

--- a/src/index.js
+++ b/src/index.js
@@ -107,13 +107,17 @@ export default class SaucelabsConnector {
     _getFreeMachineCount () {
         const params = {
             method:   'GET',
-            url:      [`https://${SAUCE_API_HOST}/rest/v1/users`, this.username, 'concurrency'].join('/'),
+            url:      [`https://${SAUCE_API_HOST}/rest/v1.2/users`, this.username, 'concurrency'].join('/'),
             username: this.username,
             password: this.accessKey
         };
 
         return got(params)
-            .then(response => JSON.parse(response.body).concurrency[this.username].remaining.overall)
+            .then(response => {
+                const teamConcurrency = JSON.parse(response.body).concurrency.team;
+
+                return teamConcurrency.allowed.vms - teamConcurrency.current.vms;
+            })
             .catch(err => {
                 throw new Error(getText(MESSAGE.failedToCallSauceApi, { err }));
             });


### PR DESCRIPTION
In our project we stumbled upon the issue, that it is not possible anymore in Saucelabs to set concurrency limits in the scope of a user account anymore. Therefore, we would like to change the _getfreeMachineCount to distinguish free machines on team level and not user level. The information of concurrency limits on team level is given with the new Saucelabs API version 1.2. More detailed information on the new API can be found here https://wiki.saucelabs.com/display/DOCS/Test+Activity+and+Usage+Methods#TestActivityandUsageMethods-GetUserConcurrency.